### PR TITLE
cleanup a removed temporary workaround

### DIFF
--- a/src/Content/peachpie-classlibrary/PhpLib.1.msbuildproj
+++ b/src/Content/peachpie-classlibrary/PhpLib.1.msbuildproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <Description>.NET class library in PHP</Description>
-	<AssemblyName>PhpLib1</AssemblyName>
+    <AssemblyName>PhpLib1</AssemblyName>
     <PackageId>PhpLib1</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<VersionSuffix>prerelease</VersionSuffix><!-- we specify version suffix to make this package a pre-release version - this is mandatory since we still have a pre-release versions of dependencies -->
@@ -18,11 +18,4 @@
     <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.8.0-*" />
     <PackageReference Include="Peachpie.NET.Sdk" Version="0.8.0-*" PrivateAssets="Build" />
   </ItemGroup>
-  
-  <!-- A temporary solution, import C# Visual Studio design time targets in order to be able to load the project in Visual Studio -->
-  <PropertyGroup>
-    <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
-  </PropertyGroup>
-  <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
-
 </Project>

--- a/src/Content/peachpie-console/PhpConsole.1.msbuildproj
+++ b/src/Content/peachpie-console/PhpConsole.1.msbuildproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
-	<StartupObject>program.php</StartupObject>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <StartupObject>program.php</StartupObject>
     <Description>Simpliest PHP project for .NET Core, a console application.</Description>
   </PropertyGroup>
 
@@ -15,11 +15,4 @@
     <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.8.0-*" />
     <PackageReference Include="Peachpie.NET.Sdk" Version="0.8.0-*" PrivateAssets="Build" />
   </ItemGroup>
-  
-  <!-- A temporary solution, import C# Visual Studio design time targets in order to be able to load the project in Visual Studio -->
-  <PropertyGroup>
-    <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
-  </PropertyGroup>
-  <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
-
 </Project>

--- a/src/Content/peachpie-web/Website/Website.msbuildproj
+++ b/src/Content/peachpie-web/Website/Website.msbuildproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.6</TargetFramework>
-	<AssemblyName>MyWebsite.1</AssemblyName>
+    <AssemblyName>MyWebsite.1</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,11 +14,4 @@
     <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.8.0-*" />
     <PackageReference Include="Peachpie.NET.Sdk" Version="0.8.0-*" PrivateAssets="Build" />
   </ItemGroup>
-  
-  <!-- A temporary solution, import C# Visual Studio design time targets in order to be able to load the project in Visual Studio -->
-  <PropertyGroup>
-    <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
-  </PropertyGroup>
-  <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
-
 </Project>


### PR DESCRIPTION
- workaround was necessary for VS2017 up to 15.3 (cca), not needed now
- workaround caused issues (MSB4020) when compiling using `dotnet` (SDK
1.1.4 +)