### PR TITLE
updated version `0.9.0`

### DIFF
--- a/src/Content/peachpie-classlibrary/.template.config/template.json
+++ b/src/Content/peachpie-classlibrary/.template.config/template.json
@@ -3,7 +3,7 @@
   "classifications": [ "Library" ],
   "name": "Peachpie Class library",
   "identity": "Peachpie.Templates.ClassLibrary",
-  "shortName": "peachpie-classlibrary",
+  "shortName": "classlib",
   "sourceName": "PhpLib.1",
   "preferNameDirectory" : "true",
   "groupIdentity": "Peachpie.Templates.ClassLibrary", // .NET CLI 1.x workaround (https://github.com/dotnet/templating/issues/649)

--- a/src/Content/peachpie-classlibrary/PhpLib.1.msbuildproj
+++ b/src/Content/peachpie-classlibrary/PhpLib.1.msbuildproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.8.0-*" />
-    <PackageReference Include="Peachpie.NET.Sdk" Version="0.8.0-*" PrivateAssets="Build" />
+    <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.9.0-*" />
+    <PackageReference Include="Peachpie.NET.Sdk" Version="0.9.0-*" PrivateAssets="Build" />
   </ItemGroup>
 </Project>

--- a/src/Content/peachpie-console/.template.config/template.json
+++ b/src/Content/peachpie-console/.template.config/template.json
@@ -3,7 +3,7 @@
   "classifications": [ "Console" ],
   "name": "Peachpie console application",
   "identity": "Peachpie.Templates.ConsoleApp",
-  "shortName": "peachpie-console",  
+  "shortName": "console",  
   "sourceName": "PhpConsole.1",
   "preferNameDirectory" : "true",
   "groupIdentity": "Peachpie.Templates.ConsoleApp", // .NET CLI 1.x workaround (https://github.com/dotnet/templating/issues/649)

--- a/src/Content/peachpie-console/PhpConsole.1.msbuildproj
+++ b/src/Content/peachpie-console/PhpConsole.1.msbuildproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.8.0-*" />
-    <PackageReference Include="Peachpie.NET.Sdk" Version="0.8.0-*" PrivateAssets="Build" />
+    <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.9.0-*" />
+    <PackageReference Include="Peachpie.NET.Sdk" Version="0.9.0-*" PrivateAssets="Build" />
   </ItemGroup>
 </Project>

--- a/src/Content/peachpie-web/.template.config/template.json
+++ b/src/Content/peachpie-web/.template.config/template.json
@@ -3,7 +3,7 @@
   "classifications": [ "Web", "Empty" ],
   "name": "Peachpie web application",
   "identity": "Peachpie.Templates.WebApp",
-  "shortName": "peachpie-web",
+  "shortName": "web",
   "sourceName": "MyWebsite.1",
   "preferNameDirectory" : "true",
   "groupIdentity": "Peachpie.Templates.WebApp", // .NET CLI 1.x workaround (https://github.com/dotnet/templating/issues/649)

--- a/src/Content/peachpie-web/Server/Server.csproj
+++ b/src/Content/peachpie-web/Server/Server.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
-    <PackageReference Include="Peachpie.NETCore.Web" Version="0.8.0-*" />
+    <PackageReference Include="Peachpie.NETCore.Web" Version="0.9.0-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Content/peachpie-web/Website/Website.msbuildproj
+++ b/src/Content/peachpie-web/Website/Website.msbuildproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.8.0-*" />
-    <PackageReference Include="Peachpie.NET.Sdk" Version="0.8.0-*" PrivateAssets="Build" />
+    <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.9.0-*" />
+    <PackageReference Include="Peachpie.NET.Sdk" Version="0.9.0-*" PrivateAssets="Build" />
   </ItemGroup>
 </Project>

--- a/src/Peachpie.Templates.nuspec
+++ b/src/Peachpie.Templates.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Peachpie.Templates</id>
-        <version>0.8.0</version>
+        <version>0.9.0</version>
         <description>Templates of PHP projects for .NET platform using Peachpie Compiler.</description>
         <authors>Peachpie, Petr Houska</authors>
         <language>en-US</language>
         <projectUrl>https://github.com/peachpiecompiler/peachpie</projectUrl>
         <licenseUrl>https://github.com/peachpiecompiler/peachpie/blob/master/LICENSE.txt</licenseUrl>
-        <copyright>Copyright 2017. All right Reserved.</copyright>
+        <copyright>Copyright 2018. All right Reserved.</copyright>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <packageTypes>
             <packageType name="Template" />


### PR DESCRIPTION
- templates for peachpie 0.9.0
- short names of templates updated to match common names (console, web,
classlib)